### PR TITLE
Change default download url to the lem menu server's SRP config

### DIFF
--- a/src/main/java/net/kyrptonaught/lemclienthelper/ResourcePreloader/ResourcePreloaderConfig.java
+++ b/src/main/java/net/kyrptonaught/lemclienthelper/ResourcePreloader/ResourcePreloaderConfig.java
@@ -4,7 +4,7 @@ import blue.endless.jankson.Comment;
 import net.kyrptonaught.kyrptconfig.config.AbstractConfigFile;
 
 public class ResourcePreloaderConfig implements AbstractConfigFile {
-    public static final String DEFAULT_URL = "https://raw.githubusercontent.com/DBTDerpbox/Legacy-Edition-Battle/main/config/switchableresourcepacksconfig.json5";
+    public static final String DEFAULT_URL = "https://raw.githubusercontent.com/DBTDerpbox/LEM-Menu-Server/main/config/serverutils/switchableresourcepacks.json5";
     @Comment("URL to download the list of packs from")
     public String URL = DEFAULT_URL;
 


### PR DESCRIPTION
this will allow me to have all 3 minigames have their packs all downloadable from lem client helper's preload feature, as the menu server will have all the packs for every game in its SRP config