### PR TITLE
Disable Mixins with Incompatible mods

### DIFF
--- a/src/main/java/net/kyrptonaught/lemclienthelper/LCHMixinPlugin.java
+++ b/src/main/java/net/kyrptonaught/lemclienthelper/LCHMixinPlugin.java
@@ -1,0 +1,51 @@
+package net.kyrptonaught.lemclienthelper;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public final class LCHMixinPlugin implements IMixinConfigPlugin {
+
+    private static final String[] SMALLINV= {
+        "net.kyrptonaught.lemclienthelper.mixin.SmallInv.HandledScreenMixin",
+        "net.kyrptonaught.lemclienthelper.mixin.SmallInv.MinecraftClientMixin",
+        "net.kyrptonaught.lemclienthelper.mixin.SmallInv.ScreenHandlerMixin",
+        "net.kyrptonaught.lemclienthelper.mixin.SmallInv.invs.GenericContainerScreenMixin",
+        "net.kyrptonaught.lemclienthelper.mixin.SmallInv.invs.InventoryScreenMixin",
+        "net.kyrptonaught.lemclienthelper.mixin.SmallInv.invs.MultipleScreenMixin"
+    };
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (FabricLoader.getInstance().isModLoaded("legacy")) {
+            for (String i : SMALLINV) {
+                if (mixinClassName.equals(i)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void onLoad(String mixinPackage) { }
+
+    @Override
+    public String getRefMapperConfig() { return null; }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) { }
+
+    @Override
+    public List<String> getMixins() { return null; }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) { }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) { }
+}

--- a/src/main/java/net/kyrptonaught/lemclienthelper/LEMClientHelperMod.java
+++ b/src/main/java/net/kyrptonaught/lemclienthelper/LEMClientHelperMod.java
@@ -1,5 +1,7 @@
 package net.kyrptonaught.lemclienthelper;
 
+import org.apache.logging.log4j.LogManager;
+
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.loader.api.FabricLoader;
@@ -36,6 +38,8 @@ public class LEMClientHelperMod implements ClientModInitializer {
         // if (FabricLoader.getInstance().isModLoaded("lambdacontrols"))
         if (FabricLoader.getInstance().isModLoaded("midnightcontrols"))
             registerControllerKeys();
+        if(FabricLoader.getInstance().isModLoaded("legacy"))
+            LogManager.getLogger().warn("Legacy4J has been detected, one or more features may be disabled.");
         //TODO: Implement this armor hud with config and or server integration
         configManager.load();
     }

--- a/src/main/resources/lemclienthelper.mixins.json
+++ b/src/main/resources/lemclienthelper.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "net.kyrptonaught.lemclienthelper.mixin",
   "compatibilityLevel": "JAVA_17",
+  "plugin": "net.kyrptonaught.lemclienthelper.LCHMixinPlugin",
   "client": [
     "customWorldBorder.WorldBorderMixin",
     "ResourcePreloader.ClientBuiltInResourcePackProviderMixin",


### PR DESCRIPTION
Implementation of IMixinConfigPlugin
Resolves LCH's #9 & Legacy4j's [#86](https://github.com/Wilyicaro/Legacy-Minecraft/issues/86)
Albeit not the most preferable fix to this issue.

Disables mixins that conflict with Legacy4j's mixins.
