### PR TITLE
Midnight update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,9 @@ dependencies {
 	//modImplementation "com.ptsmods:devlogin:3.3.2"
 
 	//midnightcontrols
-	modImplementation "dev.lambdaurora:spruceui:5.0.3+1.20.2"
-	modImplementation "maven.modrinth:midnightlib:1.5.0-fabric"
-	modImplementation "maven.modrinth:midnightcontrols:1.9.0+1.20.2"
+	modImplementation "dev.lambdaurora:spruceui:5.0.3+1.20.4"
+	modImplementation "maven.modrinth:midnightlib:1.5.3-fabric"
+	modImplementation "maven.modrinth:midnightcontrols:1.9.3+1.20.4"
 	api('org.aperlambda:lambdajcommon:1.8.1') {
 		exclude group: 'com.google.code.gson'
 		exclude group: 'com.google.guava'

--- a/src/main/java/net/kyrptonaught/lemclienthelper/TakeEverything/LambdControlsCompat.java
+++ b/src/main/java/net/kyrptonaught/lemclienthelper/TakeEverything/LambdControlsCompat.java
@@ -4,11 +4,14 @@ import eu.midnightdust.midnightcontrols.client.MidnightControlsClient;
 import eu.midnightdust.midnightcontrols.client.compat.CompatHandler;
 import eu.midnightdust.midnightcontrols.client.compat.MidnightControlsCompat;
 import eu.midnightdust.midnightcontrols.client.controller.ButtonBinding;
-import eu.midnightdust.midnightcontrols.client.controller.PressAction;
 import net.kyrptonaught.lemclienthelper.LEMClientHelperMod;
-import net.minecraft.screen.PlayerScreenHandler;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
+import net.minecraft.client.gui.screen.ingame.Generic3x3ContainerScreen;
+import net.minecraft.client.gui.screen.ingame.ShulkerBoxScreen;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.glfw.GLFW;
+
 
 
 public class LambdControlsCompat implements CompatHandler {
@@ -17,23 +20,25 @@ public class LambdControlsCompat implements CompatHandler {
         MidnightControlsCompat.registerCompatHandler(new LambdControlsCompat());
     }
 
-    private static final PressAction TAKE_EVERYTHING = (client, button, value, action) -> {
-        if (client.currentScreen != null && client.player != null && !(client.player.currentScreenHandler instanceof PlayerScreenHandler)) {
+    public static boolean takeEverything() {
+        if (MinecraftClient.getInstance().player != null) {
             TakeEverythingNetworking.sendTakeEverythingPacket();
             return true;
         }
         return false;
-    };
+    }
+
 
     @Override
     public void handle(@NotNull MidnightControlsClient mod) {
         new ButtonBinding.Builder(LEMClientHelperMod.MOD_ID + ".takeeverything")
                 .buttons(GLFW.GLFW_GAMEPAD_BUTTON_LEFT_THUMB)
                 .onlyInInventory()
-                .action(TAKE_EVERYTHING)
-                .cooldown()
                 .category(ButtonBinding.INVENTORY_CATEGORY)
-                //.linkKeybind(LEBClientHelperMod.takeEverythingKey)
+                .action((client,action,value,buttonState)->takeEverything()).cooldown()
+                .filter(((client, buttonBinding) -> client.currentScreen instanceof GenericContainerScreen || 
+                                                    client.currentScreen instanceof Generic3x3ContainerScreen ||
+                                                    client.currentScreen instanceof ShulkerBoxScreen ))
                 .register();
     }
 }

--- a/src/main/java/net/kyrptonaught/lemclienthelper/TakeEverything/LambdControlsCompat.java
+++ b/src/main/java/net/kyrptonaught/lemclienthelper/TakeEverything/LambdControlsCompat.java
@@ -15,13 +15,19 @@ import org.lwjgl.glfw.GLFW;
 
 
 public class LambdControlsCompat implements CompatHandler {
+    private static final MinecraftClient clientInstance = MinecraftClient.getInstance();
+    /**
+     * Using a static variable for the client's instance to avoid resource leak in
+     * the take everything bool, though I'm not sure if checking for the
+     * player is totally nessisary.
+     */
 
     public static void register() {
         MidnightControlsCompat.registerCompatHandler(new LambdControlsCompat());
     }
 
     public static boolean takeEverything() {
-        if (MinecraftClient.getInstance().player != null) {
+        if (clientInstance.player != null) {
             TakeEverythingNetworking.sendTakeEverythingPacket();
             return true;
         }
@@ -32,13 +38,19 @@ public class LambdControlsCompat implements CompatHandler {
     @Override
     public void handle(@NotNull MidnightControlsClient mod) {
         new ButtonBinding.Builder(LEMClientHelperMod.MOD_ID + ".takeeverything")
+                .category(ButtonBinding.INVENTORY_CATEGORY)        
                 .buttons(GLFW.GLFW_GAMEPAD_BUTTON_LEFT_THUMB)
+                .action((client,action,value,buttonState)->takeEverything())
                 .onlyInInventory()
-                .category(ButtonBinding.INVENTORY_CATEGORY)
-                .action((client,action,value,buttonState)->takeEverything()).cooldown()
                 .filter(((client, buttonBinding) -> client.currentScreen instanceof GenericContainerScreen || 
                                                     client.currentScreen instanceof Generic3x3ContainerScreen ||
                                                     client.currentScreen instanceof ShulkerBoxScreen ))
-                .register();
+                .register();                        /**
+                                                     * Filter limits the screens where the keybind is active
+                                                     * Currently can be used in: Barrels/Chests, Shulkers, & Hoppers/Droppers
+                                                     * This can be expanded to allow for more inventory screens,
+                                                     * However I don't think that we will often need to send
+                                                     * a take everything packet for a brewing stand/beacon
+                                                     */
     }
 }


### PR DESCRIPTION
Updates Midnight controls dependencies.
Reformats `LambdControlsCompat` to be more in-line with Midnight's built-in compatibility classes.

Take everything (Controller Bind) now only works on:
* Generic containers (Barrels/Chests)
* 3x3 containers (Hoppers/Droppers)
* Shulker Boxes

Resolves #10 
