### PR TITLE
Mark Legacy4j as breaking

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,5 +36,8 @@
   ],
   "depends": {
     "fabric": "*"
-  }
+  },
+  "breaks": {
+    "legacy": "*"
+  } 
 }


### PR DESCRIPTION
In addition to the mixin conflicts, Legacy4j also causes some other UI related issues.
marks the mod as breaking until compatibility is finished.