### PR TITLE
Hide status bars in lobby.

### DIFF
--- a/src/main/java/net/kyrptonaught/lemclienthelper/config/ModMenuIntegration.java
+++ b/src/main/java/net/kyrptonaught/lemclienthelper/config/ModMenuIntegration.java
@@ -87,6 +87,8 @@ public class ModMenuIntegration implements ModMenuApi {
             clientGUISection.addConfigItem(new BooleanItem(Text.translatable("key.lemclienthelper.clientgui.enabled"), clientGUI.enabled, true).setSaveConsumer(val -> clientGUI.enabled = val));
             clientGUISection.addConfigItem(new BooleanItem(Text.translatable("key.lemclienthelper.clientgui.alwaysshow"), clientGUI.alwaysEnabled, false).setSaveConsumer(val -> clientGUI.alwaysEnabled = val));
 
+            clientGUISection.addConfigItem(new BooleanItem(Text.translatable("key.lemclienthelper.clientgui.hidebars"), clientGUI.hideStatusBarsEnabled, true).setSaveConsumer(val -> clientGUI.hideStatusBarsEnabled = val));
+
             FloatItem armorHudScale = (FloatItem) clientGUISection.addConfigItem(new FloatItem(Text.translatable("key.lemclienthelper.clientgui.armorscale"), clientGUI.armorHudScale, 1f));
             armorHudScale.setMinMax(1f, 4f);
             armorHudScale.setSaveConsumer(val -> clientGUI.armorHudScale = val);

--- a/src/main/java/net/kyrptonaught/lemclienthelper/hud/HudConfig.java
+++ b/src/main/java/net/kyrptonaught/lemclienthelper/hud/HudConfig.java
@@ -12,4 +12,6 @@ public class HudConfig implements AbstractConfigFile {
     public float xOffset = 20;
 
     public float transparency =.75f;
+
+    public boolean hideStatusBarsEnabled = true;
 }

--- a/src/main/java/net/kyrptonaught/lemclienthelper/mixin/hideStatusBars/HideStatusBars.Java
+++ b/src/main/java/net/kyrptonaught/lemclienthelper/mixin/hideStatusBars/HideStatusBars.Java
@@ -18,15 +18,16 @@ public class HideStatusBars {
     @Unique
     private final Identifier Lobby = new Identifier("lem.base","lobby");
 
-    @Unique
-    @NotNull
-    private final ClientPlayerEntity player = MinecraftClient.getInstance().player;
-
     @WrapOperation(method = "render", at= @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;renderStatusBars(Lnet/minecraft/client/gui/DrawContext;)V"))
     public void hideHearts(InGameHud instance, DrawContext context, Operation<Void> original) {
+        ClientPlayerEntity player = MinecraftClient.getInstance().player;
         // Player is in the lobby, Player is in adventure mode, config is enabled.
-        if (player.getWorld().getRegistryKey().getValue().equals(Lobby) && !player.getAbilities().allowModifyWorld && HudMod.getConfig().hideStatusBarsEnabled) {
-            return;
+        if (player != null) {
+            if (player.getWorld().getRegistryKey().getValue().equals(Lobby) && !player.getAbilities().allowModifyWorld && HudMod.getConfig().hideStatusBarsEnabled) {
+                return;
+            } else {
+                original.call(instance, context);
+            }
         } else {
             original.call(instance, context);
         }

--- a/src/main/java/net/kyrptonaught/lemclienthelper/mixin/hideStatusBars/HideStatusBars.Java
+++ b/src/main/java/net/kyrptonaught/lemclienthelper/mixin/hideStatusBars/HideStatusBars.Java
@@ -1,0 +1,34 @@
+package net.kyrptonaught.lemclienthelper.mixin.hideStatusBars;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.kyrptonaught.lemclienthelper.hud.HudMod;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(InGameHud.class)
+public class HideStatusBars {
+    @Unique
+    private final Identifier Lobby = new Identifier("lem.base","lobby");
+
+    @Unique
+    @NotNull
+    private final ClientPlayerEntity player = MinecraftClient.getInstance().player;
+
+    @WrapOperation(method = "render", at= @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;renderStatusBars(Lnet/minecraft/client/gui/DrawContext;)V"))
+    public void hideHearts(InGameHud instance, DrawContext context, Operation<Void> original) {
+        // Player is in the lobby, Player is in adventure mode, config is enabled.
+        if (player.getWorld().getRegistryKey().getValue().equals(Lobby) && !player.getAbilities().allowModifyWorld && HudMod.getConfig().hideStatusBarsEnabled) {
+            return;
+        } else {
+            original.call(instance, context);
+        }
+    }
+}

--- a/src/main/resources/assets/lemclienthelper/lang/en_us.json
+++ b/src/main/resources/assets/lemclienthelper/lang/en_us.json
@@ -24,6 +24,7 @@
   "key.lemclienthelper.clientgui": "Armor HUD",
   "key.lemclienthelper.clientgui.enabled": "Enabled Armor HUD",
   "key.lemclienthelper.clientgui.alwaysshow": "Always Show Armor HUD",
+  "key.lemclienthelper.clientgui.hidebars": "Hide status bars in lobby.",
   "key.lemclienthelper.clientgui.armorscale": "Armor HUD Scale Modifier",
   "key.lemclienthelper.clientgui.armorscale.tooltip": "Sets the scale the Armor HUD will be rendered at.\nValues between 1-4.",
   "key.lemclienthelper.clientgui.xOffset": "Armor HUD X Offset",

--- a/src/main/resources/lemclienthelper.mixins.json
+++ b/src/main/resources/lemclienthelper.mixins.json
@@ -5,6 +5,7 @@
   "client": [
     "bookGui.BookScreenMixin",
     "customWorldBorder.WorldBorderMixin",
+    "hideStatusBars.hideStatusBars",
     "ResourcePreloader.ClientBuiltInResourcePackProviderMixin",
     "SmallInv.HandledScreenMixin",
     "SmallInv.MidnightControlsMixin",


### PR DESCRIPTION
Adds a new config to disable status bar rendering while in lobby.
![Before](https://github.com/user-attachments/assets/4830f277-0413-4b17-8552-49c629c5373f)
![After](https://github.com/user-attachments/assets/46ac7191-4198-4f9f-a79d-56955acea7c4)
